### PR TITLE
Added support of _ENV global var

### DIFF
--- a/parser/scanner.re
+++ b/parser/scanner.re
@@ -635,6 +635,11 @@ int xx_get_token(xx_scanner_state *s, xx_scanner_token *token) {
 					token->opcode = XX_T_IDENTIFIER;
 					return 0;
 				}
+
+				if (!strcmp(token->value, "_ENV")) {
+					token->opcode = XX_T_IDENTIFIER;
+					return 0;
+				}
 			}
 
 			/* This is hack */

--- a/unit-tests/Data/globals/simple.zep
+++ b/unit-tests/Data/globals/simple.zep
@@ -1,0 +1,16 @@
+namespace Example;
+
+class Test
+{
+	public function all()
+	{
+		var _get = _GET;
+		var _post = _POST;
+		var _request = _REQUEST;
+		var _cookie = _COOKIE;
+		var _server = _SERVER;
+		var _session = _SESSION;
+		var _files = _FILES;
+		var _env = _ENV;
+	}
+}

--- a/unit-tests/Expected/globals/simple.php
+++ b/unit-tests/Expected/globals/simple.php
@@ -1,0 +1,214 @@
+<?php
+
+return [
+    [
+        'type' => 'namespace',
+        'name' => 'Example',
+        'file' => data_path('globals/simple.zep'),
+        'line' => 3,
+        'char' => 5,
+    ],
+    [
+        'type' => 'class',
+        'name' => 'Test',
+        'abstract' => 0,
+        'final' => 0,
+        'definition' => [
+                'methods' => [
+                        [
+                            'visibility' => ['public'],
+                            'type' => 'method',
+                            'name' => 'all',
+                            'statements' => [
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_get',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_GET',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 7,
+                                                            'char' => 18,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 7,
+                                                    'char' => 18,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 8,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_post',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_POST',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 8,
+                                                            'char' => 20,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 8,
+                                                    'char' => 20,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 9,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_request',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_REQUEST',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 9,
+                                                            'char' => 26,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 9,
+                                                    'char' => 26,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 10,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_cookie',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_COOKIE',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 10,
+                                                            'char' => 24,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 10,
+                                                    'char' => 24,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 11,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_server',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_SERVER',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 11,
+                                                            'char' => 24,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 11,
+                                                    'char' => 24,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 12,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_session',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_SESSION',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 12,
+                                                            'char' => 26,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 12,
+                                                    'char' => 26,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 13,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_files',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_FILES',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 13,
+                                                            'char' => 22,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 13,
+                                                    'char' => 22,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 14,
+                                        'char' => 5,
+                                    ],
+                                    [
+                                        'type' => 'declare',
+                                        'data-type' => 'variable',
+                                        'variables' => [
+                                                [
+                                                    'variable' => '_env',
+                                                    'expr' => [
+                                                            'type' => 'variable',
+                                                            'value' => '_ENV',
+                                                            'file' => data_path('globals/simple.zep'),
+                                                            'line' => 14,
+                                                            'char' => 18,
+                                                        ],
+                                                    'file' => data_path('globals/simple.zep'),
+                                                    'line' => 14,
+                                                    'char' => 18,
+                                                ],
+                                            ],
+                                        'file' => data_path('globals/simple.zep'),
+                                        'line' => 15,
+                                        'char' => 2,
+                                    ],
+                                ],
+                            'file' => data_path('globals/simple.zep'),
+                            'line' => 5,
+                            'last-line' => 16,
+                            'char' => 16,
+                        ],
+                    ],
+                'file' => data_path('globals/simple.zep'),
+                'line' => 3,
+                'char' => 5,
+            ],
+        'file' => data_path('globals/simple.zep'),
+        'line' => 3,
+        'char' => 5,
+    ],
+];

--- a/unit-tests/Extension/ParserGlobalsTests.php
+++ b/unit-tests/Extension/ParserGlobalsTests.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Zephir\Parser\Tests;
+
+class ParserGlobalsTest extends TestCase
+{
+    /** @test */
+    public function shouldProperlyParseGlobals()
+    {
+        $this->assertSame(expected('globals/simple.php'), $this->parseFile('globals/simple.zep'));
+    }
+}

--- a/unit-tests/functions.php
+++ b/unit-tests/functions.php
@@ -9,7 +9,7 @@
  | This source file is subject the MIT license, that is bundled with        |
  | this package in the file LICENSE, and is available through the           |
  | world-wide-web at the following url:                                     |
- | http://zephir-lang.com/license.html                                      |
+ | https://zephir-lang.com/license.html                                     |
  |                                                                          |
  | If you did not receive a copy of the MIT license and are unable          |
  | to obtain it through the world-wide-web, please send a note to           |


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/zephir/issues/1224

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/php-zephir-parser/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Added support of `$_ENV` global var.

Thanks