### PR TITLE
Add PHP SDK 2.0 for PHP 7.*+

### DIFF
--- a/README.WIN32-BUILD-SYSTEM
+++ b/README.WIN32-BUILD-SYSTEM
@@ -22,9 +22,10 @@ Parts which are only necessary for a specific PHP version, are marked as such.
   * Make sure it is in the PATH, as for example below:
     setx path "%path%;c:\path-to-php\"
 
-* Install PHP SDK: http://windows.php.net/downloads/php-sdk/
+* Install PHP SDK for PHP 5.6: http://windows.php.net/downloads/php-sdk/
   (Currently `php-sdk-binary-tools-20110915.zip` is the newest):
     setx php_sdk "c:\path-to-php-sdk"
+* Install PHP SDK 2.0 for PHP 7.0+: https://github.com/OSTC/php-sdk-binary-tools
 
 * Download PHP Developer Pack(NTS!): http://windows.php.net/downloads/releases/
   (Or build it yourself with `--enable-debug --disable-zts` and `nmake build-devel`,


### PR DESCRIPTION
Hello!

* Type: documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/php-zephir-parser/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Microsoft maintain a PHP SDK for php7.0+ with backwards compatibility. Also merged into zephir.

Thanks
