### PR TITLE
fix phpt tests by using %d rather than 88 or 91.

### DIFF
--- a/tests/operators/assignments/concat.phpt
+++ b/tests/operators/assignments/concat.phpt
@@ -36,14 +36,14 @@ array(3) {
           ["value"]=>
           string(1) "1"
           ["file"]=>
-          string(91) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(8)
           ["char"]=>
           int(14)
         }
         ["file"]=>
-        string(91) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(8)
         ["char"]=>
@@ -51,7 +51,7 @@ array(3) {
       }
     }
     ["file"]=>
-    string(91) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(9)
     ["char"]=>
@@ -78,14 +78,14 @@ array(3) {
           ["value"]=>
           string(1) "2"
           ["file"]=>
-          string(91) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(9)
           ["char"]=>
           int(14)
         }
         ["file"]=>
-        string(91) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(9)
         ["char"]=>
@@ -93,7 +93,7 @@ array(3) {
       }
     }
     ["file"]=>
-    string(91) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(10)
     ["char"]=>
@@ -120,14 +120,14 @@ array(3) {
           ["value"]=>
           string(1) "a"
           ["file"]=>
-          string(91) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(10)
           ["char"]=>
           int(12)
         }
         ["file"]=>
-        string(91) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(10)
         ["char"]=>
@@ -135,7 +135,7 @@ array(3) {
       }
     }
     ["file"]=>
-    string(91) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(11)
     ["char"]=>

--- a/tests/operators/assignments/div.phpt
+++ b/tests/operators/assignments/div.phpt
@@ -36,14 +36,14 @@ array(2) {
           ["value"]=>
           string(2) "42"
           ["file"]=>
-          string(88) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(8)
           ["char"]=>
           int(13)
         }
         ["file"]=>
-        string(88) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(8)
         ["char"]=>
@@ -51,7 +51,7 @@ array(2) {
       }
     }
     ["file"]=>
-    string(88) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(9)
     ["char"]=>
@@ -78,14 +78,14 @@ array(2) {
           ["value"]=>
           string(3) "num"
           ["file"]=>
-          string(88) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(9)
           ["char"]=>
           int(14)
         }
         ["file"]=>
-        string(88) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(9)
         ["char"]=>
@@ -93,7 +93,7 @@ array(2) {
       }
     }
     ["file"]=>
-    string(88) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(10)
     ["char"]=>

--- a/tests/operators/assignments/mod.phpt
+++ b/tests/operators/assignments/mod.phpt
@@ -33,14 +33,14 @@ array(1) {
           ["value"]=>
           string(3) "360"
           ["file"]=>
-          string(88) "%s"
+          string(%d) "%s"
           ["line"]=>
           int(7)
           ["char"]=>
           int(20)
         }
         ["file"]=>
-        string(88) "%s"
+        string(%d) "%s"
         ["line"]=>
         int(7)
         ["char"]=>
@@ -48,7 +48,7 @@ array(1) {
       }
     }
     ["file"]=>
-    string(88) "%s"
+    string(%d) "%s"
     ["line"]=>
     int(8)
     ["char"]=>


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/php-zephir-parser/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
