### PR TITLE
Fix deprecated set-env action syntax for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
 
         include:
           - name: Ubuntu
-            os: ubuntu-latest
+            os: ubuntu-18.04
             ccov: ON
 
           - name: macOS
@@ -79,10 +79,10 @@ jobs:
           mkdir -p $HOME/.cache/re2c
           mkdir -p $HOME/.local/opt/re2c
 
-          echo "::set-env name=RE2C_VERSION::${{ matrix.re2c }}"
-          echo "::set-env name=PATH::$PATH:$HOME/bin:$(brew --prefix lcov)/bin"
-          echo "::set-env name=MAKEFLAGS::-j$(getconf _NPROCESSORS_ONLN)"
-          echo "::set-env name=CI::true"
+          echo "RE2C_VERSION:={{ matrix.re2c }}" >> $GITHUB_ENV
+          echo "PATH=$PATH:$HOME/bin:$(brew --prefix lcov)/bin" >> $GITHUB_ENV
+          echo "MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)" >> $GITHUB_ENV
+          echo "CI=true" >> $GITHUB_ENV
 
       - name: Setup Core Dump (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir -p $HOME/.cache/re2c
           mkdir -p $HOME/.local/opt/re2c
 
-          echo "RE2C_VERSION:={{ matrix.re2c }}" >> $GITHUB_ENV
+          echo "RE2C_VERSION=${{ matrix.re2c }}" >> $GITHUB_ENV
           echo "PATH=$PATH:$HOME/bin:$(brew --prefix lcov)/bin" >> $GITHUB_ENV
           echo "MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)" >> $GITHUB_ENV
           echo "CI=true" >> $GITHUB_ENV

--- a/tests/base/extension_info.phpt
+++ b/tests/base/extension_info.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test extension info
+--SKIPIF--
+<?php include(__DIR__ . '/../skipif.inc'); ?>
+--FILE--
+<?php
+
+function contains($input, $expected) {
+    return strpos($input, $expected) !== false
+        ? $expected
+        : 'not contains';
+}
+
+$version = phpversion('Zephir Parser');
+$actual = trim(file_get_contents(__DIR__ . '/../../VERSION'));
+
+$compare = $version === $actual;
+var_dump($compare);
+
+ob_start();
+phpinfo(INFO_MODULES);
+$info = trim(ob_get_clean());
+
+echo contains($info, 'Zephir Parser').PHP_EOL;
+echo contains($info, 'The Zephir Parser delivered as a C extension for the PHP language.').PHP_EOL;
+echo contains($info, 'Zephir Parser => enabled').PHP_EOL;
+echo contains($info, 'Author => Zephir Team and contributors').PHP_EOL;
+echo contains($info, 'Version =>').PHP_EOL;
+echo contains($info, 'Build Date =>').PHP_EOL;
+?>
+--EXPECT--
+bool(true)
+Zephir Parser
+The Zephir Parser delivered as a C extension for the PHP language.
+Zephir Parser => enabled
+Author => Zephir Team and contributors
+Version =>
+Build Date =>


### PR DESCRIPTION
Hello!

* Type: code quality

Small description of change:

- Fixed deprecated `set-env` syntax for GitHub actions

Thanks
